### PR TITLE
Possible fix for some crashes after start / stop

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -142,6 +142,10 @@ DQMProcessor::RequestMaker()
 
     // Sleep until the next time
     std::this_thread::sleep_until(next_time);
+    // We don't want to run if the run has stopped
+    if (!m_run_marker) {
+      break;
+    }
 
     // Make sure that the process is not running and a request can be made
     // otherwise we wait for more time


### PR DESCRIPTION
I think this may fix some crashes after start / stop, at least it doesn't do anything bad: if the run has stopped then we don't want to run the algorithms