### PR TITLE
Fix string to be able to input IP addresses

### DIFF
--- a/schema/dqm/dqmprocessor.jsonnet
+++ b/schema/dqm/dqmprocessor.jsonnet
@@ -14,8 +14,8 @@ local s = moo.oschema.schema(ns);
 // Object structure used by the test/fake producer module
 local dqmprocessor = {
 
-    string : s.string("RunningMode", moo.re.ident,
-                            doc="A string field"),
+    string : s.string("RunningMode",
+                      doc="A string field"),
 
     time : s.number("Time", "f4", doc="A time"),
 


### PR DESCRIPTION
IP addresses could not be used for the kafka address because the schema was wrong