### PR TITLE
Fix delayed requests is readout

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -269,6 +269,9 @@ DQMProcessor::CreateRequest(std::vector<dfmessages::GeoID> m_links)
     request.component = link;
     // Some offset is required to avoid having delayed requests in readout
     // which make the TRB to take longer and longer to create the trigger records
+    // 10^5 was tried at first but wasn't enough. At 50 MHz, 10^5 = 2 ms
+    // The current value is 10^7 which seems to work after several hours of
+    // running and no delayed requests in readout
     request.window_begin = timestamp - window_size - 10000000;
     request.window_end = timestamp - 10000000;
 

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -267,8 +267,10 @@ DQMProcessor::CreateRequest(std::vector<dfmessages::GeoID> m_links)
     // TLOG() << "ONE LINK";
     dataformats::ComponentRequest request;
     request.component = link;
-    request.window_begin = timestamp - window_size;
-    request.window_end = timestamp;
+    // Some offset is required to avoid having delayed requests in readout
+    // which make the TRB to take longer and longer to create the trigger records
+    request.window_begin = timestamp - window_size - 100000;
+    request.window_end = timestamp - 100000;
 
     decision.components.push_back(request);
   }

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -269,8 +269,8 @@ DQMProcessor::CreateRequest(std::vector<dfmessages::GeoID> m_links)
     request.component = link;
     // Some offset is required to avoid having delayed requests in readout
     // which make the TRB to take longer and longer to create the trigger records
-    request.window_begin = timestamp - window_size - 100000;
-    request.window_end = timestamp - 100000;
+    request.window_begin = timestamp - window_size - 10000000;
+    request.window_end = timestamp - 10000000;
 
     decision.components.push_back(request);
   }


### PR DESCRIPTION
The cause was the the window requested was too close to the current timestamp, so an offset is added to request older data