### PR TITLE
Improvements after 2.8.2

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -164,7 +164,7 @@ DQMProcessor::RequestMaker()
                                                                       m_standard_dqm_mean_rms.unavailable_time,
                                                                       m_standard_dqm_mean_rms.num_frames,
                                                                       nullptr,
-                                                                      "Histogram every " + std::to_string(m_standard_dqm_hist.how_often) + " s"};
+                                                                      "Mean/RMS every " + std::to_string(m_standard_dqm_hist.how_often) + " s"};
   map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
                                                                       m_standard_dqm_fourier.how_often,
                                                                       m_standard_dqm_fourier.unavailable_time,
@@ -262,6 +262,7 @@ DQMProcessor::RequestMaker()
     std::thread* current_thread = new std::thread(memfunc, std::ref(*algo), std::move(element), std::ref(m_map), m_kafka_address);
 
     // Add a new entry for the current instance
+    TLOG() << "Starting to run " << analysis_instance.name;
     map[std::chrono::system_clock::now() +
         std::chrono::milliseconds(static_cast<int>(analysis_instance.between_time) * 1000)] = {
       algo, analysis_instance.between_time, analysis_instance.default_unavailable_time,

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -164,7 +164,7 @@ DQMProcessor::RequestMaker()
                                                                       m_standard_dqm_mean_rms.unavailable_time,
                                                                       m_standard_dqm_mean_rms.num_frames,
                                                                       nullptr,
-                                                                      "Mean/RMS every " + std::to_string(m_standard_dqm_hist.how_often) + " s"};
+                                                                      "Mean/RMS every " + std::to_string(m_standard_dqm_rms.how_often) + " s"};
   map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
                                                                       m_standard_dqm_fourier.how_often,
                                                                       m_standard_dqm_fourier.unavailable_time,

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -164,7 +164,7 @@ DQMProcessor::RequestMaker()
                                                                       m_standard_dqm_mean_rms.unavailable_time,
                                                                       m_standard_dqm_mean_rms.num_frames,
                                                                       nullptr,
-                                                                      "Mean and RMS every " + std::to_string(m_standard_dqm_rms.how_often) + " s"};
+                                                                      "Mean and RMS every " + std::to_string(m_standard_dqm_mean_rms.how_often) + " s"};
   map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
                                                                       m_standard_dqm_fourier.how_often,
                                                                       m_standard_dqm_fourier.unavailable_time,

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -265,7 +265,7 @@ DQMProcessor::RequestMaker()
     std::thread* current_thread = new std::thread(memfunc, std::ref(*algo), std::move(element), std::ref(m_map), m_kafka_address);
 
     // Add a new entry for the current instance
-    TLOG() << "Starting to run " << analysis_instance.name;
+    TLOG() << "Starting to run \"" << analysis_instance.name << "\"";
     map[std::chrono::system_clock::now() +
         std::chrono::milliseconds(static_cast<int>(analysis_instance.between_time) * 1000)] = {
       algo, analysis_instance.between_time, analysis_instance.default_unavailable_time,

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -164,7 +164,7 @@ DQMProcessor::RequestMaker()
                                                                       m_standard_dqm_mean_rms.unavailable_time,
                                                                       m_standard_dqm_mean_rms.num_frames,
                                                                       nullptr,
-                                                                      "Mean/RMS every " + std::to_string(m_standard_dqm_rms.how_often) + " s"};
+                                                                      "Mean and RMS every " + std::to_string(m_standard_dqm_rms.how_often) + " s"};
   map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
                                                                       m_standard_dqm_fourier.how_often,
                                                                       m_standard_dqm_fourier.unavailable_time,

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -153,24 +153,27 @@ DQMProcessor::RequestMaker()
   // Initial tasks
   // Add some offset time to let the other parts of the DAQ start
   // Typically the first and maybe second requests of data fails
-  map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&hist,
-                                                                      m_standard_dqm_hist.how_often,
-                                                                      m_standard_dqm_hist.unavailable_time,
-                                                                      m_standard_dqm_hist.num_frames,
-                                                                      nullptr,
-                                                                      "Histogram every " + std::to_string(m_standard_dqm_hist.how_often) + " s"};
-  map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&mean_rms,
-                                                                      m_standard_dqm_mean_rms.how_often,
-                                                                      m_standard_dqm_mean_rms.unavailable_time,
-                                                                      m_standard_dqm_mean_rms.num_frames,
-                                                                      nullptr,
-                                                                      "Mean and RMS every " + std::to_string(m_standard_dqm_mean_rms.how_often) + " s"};
-  map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
-                                                                      m_standard_dqm_fourier.how_often,
-                                                                      m_standard_dqm_fourier.unavailable_time,
-                                                                      m_standard_dqm_fourier.num_frames,
-                                                                      nullptr,
-                                                                      "Fourier every " + std::to_string(m_standard_dqm_fourier.how_often) + " s"};
+  if (m_standard_dqm_hist.how_often > 0)
+    map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&hist,
+                                                                        m_standard_dqm_hist.how_often,
+                                                                        m_standard_dqm_hist.unavailable_time,
+                                                                        m_standard_dqm_hist.num_frames,
+                                                                        nullptr,
+                                                                        "Histogram every " + std::to_string(m_standard_dqm_hist.how_often) + " s"};
+  if (m_standard_dqm_mean_rms.how_often > 0)
+    map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&mean_rms,
+                                                                        m_standard_dqm_mean_rms.how_often,
+                                                                        m_standard_dqm_mean_rms.unavailable_time,
+                                                                        m_standard_dqm_mean_rms.num_frames,
+                                                                        nullptr,
+                                                                        "Mean and RMS every " + std::to_string(m_standard_dqm_mean_rms.how_often) + " s"};
+  if (m_standard_dqm_fourier.how_often > 0)
+    map[std::chrono::system_clock::now() + std::chrono::seconds(10)] = {&fourier,
+                                                                        m_standard_dqm_fourier.how_often,
+                                                                        m_standard_dqm_fourier.unavailable_time,
+                                                                        m_standard_dqm_fourier.num_frames,
+                                                                        nullptr,
+                                                                        "Fourier every " + std::to_string(m_standard_dqm_fourier.how_often) + " s"};
   map[std::chrono::system_clock::now() + std::chrono::seconds(2)] =  {&chfiller,
                                                                       3,
                                                                       3,

--- a/schema/dqm/dqmprocessor.jsonnet
+++ b/schema/dqm/dqmprocessor.jsonnet
@@ -31,11 +31,11 @@ local dqmprocessor = {
                             doc="A list with indexes"),
 
     standard_dqm: s.record("StandardDQM", [
-        s.field("how_often", self.time, 1,
+        s.field("how_often", self.time, 0,
                 doc="Algorithm is run every x seconds"),
-        s.field("unavailable_time", self.time, 1,
+        s.field("unavailable_time", self.time, 0,
                 doc="When it's time to run the algorithm but it's already running wait this time"),
-        s.field("num_frames", self.count, 1,
+        s.field("num_frames", self.count, 0,
                 doc="How many frames do we process in each instance of the algorithm")
     ], doc="Standard DQM analysis"),
 

--- a/src/FourierContainer.hpp
+++ b/src/FourierContainer.hpp
@@ -79,6 +79,17 @@ FourierContainer::run(std::unique_ptr<daqdataformats::TriggerRecord> record, std
   auto wibframes = dec.decode(*record);
   // std::uint64_t timestamp = 0; // NOLINT(build/unsigned)
 
+  // Check that all the wibframes vectors have the same size, if not, something
+  // bad has happened, for now don't do anything
+  auto size = wibframes.begin()->second.size();
+  for (auto& vec : wibframes) {
+    if (vec.second.size() != size) {
+      ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
+      m_run_mark.store(false);
+      return;
+    }
+  }
+
   for (auto& [key, value] : wibframes) {
     for (auto& fr : value) {
       for (size_t ich = 0; ich < CHANNELS_PER_LINK; ++ich) {

--- a/src/HistContainer.hpp
+++ b/src/HistContainer.hpp
@@ -105,7 +105,7 @@ HistContainer::run(std::unique_ptr<daqdataformats::TriggerRecord> record, std::u
   uint64_t timestamp = 0;
 
   // Check that all the wibframes vectors have the same size, if not, something
-  // bad has happened
+  // bad has happened, for now don't do anything
   auto size = wibframes.begin()->second.size();
   for (auto& vec : wibframes) {
     if (vec.second.size() != size) {

--- a/src/HistContainer.hpp
+++ b/src/HistContainer.hpp
@@ -110,6 +110,7 @@ HistContainer::run(std::unique_ptr<daqdataformats::TriggerRecord> record, std::u
   for (auto& vec : wibframes) {
     if (vec.second.size() != size) {
       ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
+      m_run_mark.store(false);
       return;
     }
   }


### PR DESCRIPTION
This PR changes the following:

- Fixes a bug when one of the algorithms would stop working when it received corrupted data
- Adds the same check to the fourier transform
- Algorithms won't run if they are deleted in the json config (previously deleting them from the json config would make them run almost continuosly) or alternatively if the parameter that controls how often they are run is set to zero
- Additional log messages so that shifters can check if DQM is running by checking the logs