### PR TITLE
Candidate implementation of pause/resume functionality in DQMProcessor

### DIFF
--- a/plugins/DQMProcessor.hpp
+++ b/plugins/DQMProcessor.hpp
@@ -49,6 +49,8 @@ public:
 
   void do_print(const data_t&);
   void do_start(const data_t&);
+  void do_pause(const data_t&);
+  void do_resume(const data_t&);
   void do_stop(const data_t&);
   void do_configure(const data_t&);
 
@@ -87,6 +89,9 @@ private:
   int m_clock_frequency;
 
   std::unique_ptr<std::thread> m_running_thread;
+
+  // paused state, in which we don't send triggers
+  std::atomic<bool> m_paused;
 
   std::atomic<int> m_request_count{0};
   std::atomic<int> m_total_request_count{0};


### PR DESCRIPTION
In some of our system testing, things can become a little confused when there are errors reported in the dqm process logfiles.
It is my belief that these errors are not related to real problems, but rather are related to edge effects at end-run or begin-of-a-second-run.
Typically, the errors are reported by the DQM_TRB.

To help avoid these spurious errors, I wonder if people would be open to the idea of adding pause/resume handling to DQMProcessor.  If we do that, then we would be giving the DQM_TRB the same courtesy that we give to the DF TRB, that is the stopping of TriggerDecision messages *before* the Stop command is sent to the TRB.

In my tests of the code on this branch, I'm not seeing the spurious errors in the dqm process log files, but of course, it would be great for others to verify that behavior.