### PR TITLE
Added test for the current run number when receiving TimeSync messages

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -327,8 +327,6 @@ DQMProcessor::RequestMaker()
     // AnalysisInstance whose thread it refers to
 
     map.erase(task);
-
-
   }
 
   for (auto& [time, analysis_instance] : map) {
@@ -385,9 +383,14 @@ DQMProcessor::dispatch_timesync(ipm::Receiver::Response message)
 {
   ++m_received_timesync_count;
   auto timesyncmsg = serialization::deserialize<dfmessages::TimeSync>(message.data);
-  TLOG_DEBUG(13) << "Received TimeSync message with DAQ time = " << timesyncmsg.daq_time;
+  TLOG_DEBUG(13) << "Received TimeSync message with DAQ time= " << timesyncmsg.daq_time
+                 << ", run=" << timesyncmsg.run_number << " (local run number is " << m_run_number << ")";
   if (m_time_est.get() != nullptr) {
-    m_time_est->add_timestamp_datapoint(timesyncmsg);
+    if (timesyncmsg.run_number == m_run_number) {
+      m_time_est->add_timestamp_datapoint(timesyncmsg);
+    } else {
+      TLOG_DEBUG(0) << "Discarded TimeSync message from run " << timesyncmsg.run_number << " during run " << m_run_number;
+    }
   }
 }
 


### PR DESCRIPTION
…in DQMProcessor.

This PullRequest is for changes related to the addition of a run number, sequence number, and source process PID to TimeSync messages.  The run number will be used to ensure that only TimeSync messages from the current run are used, and the sequence number and source_pid fields are included for debugging purposes.  (For example, I’ve used the source_pid to verify that only TimeSyncs from Readout App 1 show up in DQM App 1, etc, *and* that all TimeSync messages show up in the Fake HSI App.)

There are correlated code changes in four repositories for this addition.
dfmessages, branch kbiery/TimeSyncRunNumber
dqm, branch kbiery/TimeSyncRunNumber
readoutlibs, branch kbiery/TimeSyncRunNumber
timinglibs, branch kbiery/TimeSyncRunNumber

Reviewer(s), please take a look at the changes and verify that things are working correctly.  Once the changes in all four packages have been reviewed, we’ll merge them to the respective develop branches.
Thanks!
