### PR TITLE
Added some checking for a valid index in Fourier::get_transform

### DIFF
--- a/include/dqm/Fourier.hpp
+++ b/include/dqm/Fourier.hpp
@@ -65,7 +65,7 @@ Fourier::fourier_prep(const std::vector<double>& input) const
   for (size_t i = 0; i < input.size(); i++) {
     output[i] = input[i];
     if (i < 100)
-      TLOG()  << "Prep " << output[i] << " " << input[i];
+      TLOG() << "Prep " << output[i] << " " << input[i];
   }
   return output;
 }
@@ -102,6 +102,11 @@ Fourier::compute_fourier_normalized()
 double
 Fourier::get_transform(int index)
 {
+  if (index < 0 || static_cast<size_t>(index) >= m_transform.size()) {
+    TLOG() << "WARNING: Fourier::get_transform called with index out of range, index=" << index
+           << ", size of m_transform vector is " << m_transform.size();
+    return 0.0;
+  }
   return m_transform[index];
 }
 


### PR DESCRIPTION
Hi Juan,
Occasionally in my integration testing, I've seen the DQM process crash.  That seems to happen at line 105 of Fourier.cpp.  It only happens about ~5% of the time or less.

To try to prevent such crashes, I made the simple-minded addition that is included on this branch.

When you get a chance, please take a look and see what you think.  

If/when I see the new code get triggered in any of my future tests, I'll let you know what the offending index value is.
Thanks,
Kurt