### PR TITLE
using fftw cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(dfmessages REQUIRED)
 find_package(RdKafka REQUIRED)
 find_package(timinglibs REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
+find_package(fftw REQUIRED)
 
 daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen(*info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
@@ -26,15 +27,15 @@ dfmessages::dfmessages
 RdKafka::rdkafka
 RdKafka::rdkafka++
 timinglibs::timinglibs
+fftw::fftw3
 )
 
 # We put here the name of our class, and the libraries we want to link with
 
-daq_add_plugin(DQMProcessor duneDAQModule LINK_LIBRARIES ${DQM_DEPENDENCIES} $ENV{FFTW_LIBRARY}/libfftw3.so)
+daq_add_plugin(DQMProcessor duneDAQModule LINK_LIBRARIES ${DQM_DEPENDENCIES})
 target_include_directories(dqm_DQMProcessor_duneDAQModule PUBLIC $ENV{FFTW_INC})
 
 # Unit tests
-daq_add_unit_test(Fourier_test LINK_LIBRARIES ${DQM_DEPENDENCIES} $ENV{FFTW_LIBRARY}/libfftw3.so)
-target_include_directories(Fourier_test PUBLIC $ENV{FFTW_INC})
+daq_add_unit_test(Fourier_test LINK_LIBRARIES ${DQM_DEPENDENCIES})
 
 daq_install()


### PR DESCRIPTION
We have recently created cmake targets files for fftw and deployed to cvmfs. This PR changes CMakeLists.txt in this repo to use those files. The cmake target used is fftw::fftw3