### PR TITLE
Add a parameter to fix an issue with slowdown rate

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -81,16 +81,12 @@ DQMProcessor::do_configure(const nlohmann::json& args)
   m_standard_dqm_fourier_sum = conf.sdqm_fourier_sum;
 
   m_link_idx = conf.link_idx;
-
   m_clock_frequency = conf.clock_frequency;
-
   m_channel_map = conf.channel_map;
-
   m_region = conf.region;
+  m_readout_window_offset = conf.readout_window_offset;
 
   m_timesync_connection = conf.timesync_connection_name;
-
-  m_readout_window_offset = conf.readout_window_offset;
 }
 
 void

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -89,6 +89,8 @@ DQMProcessor::do_configure(const nlohmann::json& args)
   m_region = conf.region;
 
   m_timesync_connection = conf.timesync_connection_name;
+
+  m_readout_window_offset = conf.readout_window_offset;
 }
 
 void
@@ -382,8 +384,8 @@ DQMProcessor::CreateRequest(std::vector<dfmessages::GeoID>& m_links, int number_
     // 10^5 was tried at first but wasn't enough. At 50 MHz, 10^5 = 2 ms
     // The current value is 10^7 which seems to work after several hours of
     // running and no delayed requests in readout
-    request.window_begin = timestamp - window_size - 10000000;
-    request.window_end = timestamp - 10000000;
+    request.window_begin = timestamp - window_size - m_readout_window_offset;
+    request.window_end = timestamp - m_readout_window_offset;
 
     decision.components.push_back(request);
   }

--- a/plugins/DQMProcessor.hpp
+++ b/plugins/DQMProcessor.hpp
@@ -98,6 +98,8 @@ private:
 
   std::string m_channel_map;
   std::unique_ptr<ChannelMap> m_map;
+
+  int m_readout_window_offset;
 };
 
 } // namespace dunedaq::dqm

--- a/schema/dqm/dqmprocessor.jsonnet
+++ b/schema/dqm/dqmprocessor.jsonnet
@@ -21,14 +21,13 @@ local dqmprocessor = {
     count : s.number("Count", "i4",
                      doc="A count of not too many things"),
 
-    big_count : s.number("BigCount", "i8",
-                         doc="A count of more things"),
-
     index : s.number("Index", "i4",
                      doc="An integer index"),
 
     index_list : s.sequence("IndexList", self.index,
                             doc="A list with indexes"),
+
+    int32 : s.number("Integer", "i32", doc="An integer"),
 
     netmgr_name : s.string("NetMgrName", doc="Connection or topic name to be used with NetworkManager"),
 
@@ -60,7 +59,11 @@ local dqmprocessor = {
         s.field("clock_frequency", self.big_count,
                 doc="Clock frequency in Hz"),
         s.field("timesync_connection_name", self.netmgr_name,
-                doc="Connection to use for receiving TimeSync messages")
+                doc="Connection to use for receiving TimeSync messages"),
+        s.field("readout_window_offset", self.i32,
+                doc="Offset to use for the windows requested to readout"),
+
+
     ], doc="Generic DQM configuration")
 };
 

--- a/schema/dqm/dqmprocessor.jsonnet
+++ b/schema/dqm/dqmprocessor.jsonnet
@@ -30,8 +30,6 @@ local dqmprocessor = {
     index_list : s.sequence("IndexList", self.index,
                             doc="A list with indexes"),
 
-    int32 : s.number("Integer", "i32", doc="An integer"),
-
     netmgr_name : s.string("NetMgrName", doc="Connection or topic name to be used with NetworkManager"),
 
     standard_dqm: s.record("StandardDQM", [
@@ -63,8 +61,8 @@ local dqmprocessor = {
                 doc="Clock frequency in Hz"),
         s.field("timesync_connection_name", self.netmgr_name,
                 doc="Connection to use for receiving TimeSync messages"),
-        s.field("readout_window_offset", self.i32,
-                doc="Offset to use for the windows requested to readout"),
+        s.field("readout_window_offset", self.big_count,
+                doc="Offset to use for the windows requested to readout")
 
 
     ], doc="Generic DQM configuration")

--- a/schema/dqm/dqmprocessor.jsonnet
+++ b/schema/dqm/dqmprocessor.jsonnet
@@ -24,6 +24,9 @@ local dqmprocessor = {
     index : s.number("Index", "i4",
                      doc="An integer index"),
 
+    big_count : s.number("BigCount", "i8",
+                         doc="A count of more things"),
+
     index_list : s.sequence("IndexList", self.index,
                             doc="A list with indexes"),
 


### PR DESCRIPTION
The new parameter will be set in the config to solve the issue that when using very large slowdown rates the data requested has never been in readout