### PR TITLE
Added TriggerActivities and TriggerCandidates to the list of Fragment…

### DIFF
--- a/src/Decoder.hpp
+++ b/src/Decoder.hpp
@@ -40,7 +40,11 @@ decodewib(daqdataformats::TriggerRecord& record)
   std::map<int, std::vector<detdataformats::wib::WIBFrame*>> wibframes;
 
   for (auto& fragment : fragments) {
-    if (fragment->get_fragment_type() == daqdataformats::FragmentType::kTriggerPrimitives) {
+    // 20-May-2022, KAB: I wonder if the following check should be on the desired fragment type
+    // instead of a veto on undesired fragment types (to avoid having to update this as new types are added)
+    if (fragment->get_fragment_type() == daqdataformats::FragmentType::kTriggerPrimitives ||
+        fragment->get_fragment_type() == daqdataformats::FragmentType::kTriggerActivities ||
+        fragment->get_fragment_type() == daqdataformats::FragmentType::kTriggerCandidates) {
       continue;
     }
     auto id = fragment->get_element_id();


### PR DESCRIPTION
… Types to avoid in Decoder::decode.

As I mentioned in a trigger PR, I noticed complaints from the DQM part of the readout_type_scan integtest when I tried a system with TCs included with each event.

The code change in this PR fixes those complaints.

As I mentioned in a comment in the code, I wonder if changing the logic so that it requires a certain fragment type might be better than excluding certain trigger types, but that might be something for the future.