### PR TITLE
Update the latest changes from 2.11.x

### DIFF
--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -208,12 +208,12 @@ DQMProcessor::RequestMaker()
   auto fourier = std::make_shared<FourierContainer>("fft_display",
                                                       CHANNELS_PER_LINK * m_link_idx.size(),
                                                       m_link_idx,
-                                                      1. / m_clock_frequency * (strcmp(m_frontend_type, "wib") ? 32 : 25),
+                                                    1. / m_clock_frequency * (strcmp(m_frontend_type.c_str(), "wib") ? 32 : 25),
                                                       m_fourier_conf.num_frames);
   auto fouriersum = std::make_shared<FourierContainer>("fft_sums_display",
                                                       4,
                                                       m_link_idx,
-                                                      1. / m_clock_frequency * (strcmp(m_frontend_type, "wib") ? 32 : 25),
+                                                       1. / m_clock_frequency * (strcmp(m_frontend_type.c_str(), "wib") ? 32 : 25),
                                                       m_fourier_sum_conf.num_frames,
                                                       true);
   auto channel_mask = std::make_shared<ChannelMask>("channel_mask_display",

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -224,7 +224,7 @@ DQMProcessor::RequestMaker()
   auto dfmodule = std::make_shared<DFModule>(m_df_algs & 1, m_df_algs & 2,
                                              m_df_algs & 4, m_df_algs & 8,
                                              m_clock_frequency, m_link_idx,
-                                             m_df_num_frames);
+                                             m_df_num_frames, m_frontend_type);
 
   // Fills the channel map at the beggining of a run
   auto chfiller = std::make_shared<ChannelMapFiller>("channelmapfiller", m_channel_map);

--- a/plugins/DQMProcessor.cpp
+++ b/plugins/DQMProcessor.cpp
@@ -198,22 +198,22 @@ DQMProcessor::RequestMaker()
 
   // Raw event display
   auto hist = std::make_shared<HistContainer>(
-      "raw_display", CHANNELS_PER_LINK * m_link_idx.size(), m_link_idx, 100, 0, 5000, false);
+      "raw_display", CHANNELS_PER_LINK * m_link_idx.size(), m_link_idx, 100, 0, 17000, false);
   // Mean and RMS
   auto mean_rms = std::make_shared<HistContainer>(
-      "rmsm_display", CHANNELS_PER_LINK * m_link_idx.size(), m_link_idx, 100, 0, 5000, true);
+      "rmsm_display", CHANNELS_PER_LINK * m_link_idx.size(), m_link_idx, 100, 0, 17000, true);
   // Fourier transform
   // The Delta of time between frames is the inverse of the sampling frequency (clock frequency)
   // but because we are sampling every TICKS_BETWEEN_TIMESTAMP ticks we have to multiply by that
   auto fourier = std::make_shared<FourierContainer>("fft_display",
                                                       CHANNELS_PER_LINK * m_link_idx.size(),
                                                       m_link_idx,
-                                                      1. / m_clock_frequency * TICKS_BETWEEN_TIMESTAMP,
+                                                      1. / m_clock_frequency * (strcmp(m_frontend_type, "wib") ? 32 : 25),
                                                       m_fourier_conf.num_frames);
   auto fouriersum = std::make_shared<FourierContainer>("fft_sums_display",
                                                       4,
                                                       m_link_idx,
-                                                      1. / m_clock_frequency * TICKS_BETWEEN_TIMESTAMP,
+                                                      1. / m_clock_frequency * (strcmp(m_frontend_type, "wib") ? 32 : 25),
                                                       m_fourier_sum_conf.num_frames,
                                                       true);
   auto channel_mask = std::make_shared<ChannelMask>("channel_mask_display",

--- a/src/DFModule.hpp
+++ b/src/DFModule.hpp
@@ -27,7 +27,7 @@ class DFModule : public AnalysisModule
 
 public:
   DFModule(bool enable_hist, bool enable_mean_rms, bool enable_fourier, bool enable_fourier_sum,
-           int clock_frequency, std::vector<int>& ids, int num_frames);
+           int clock_frequency, std::vector<int>& ids, int num_frames, std::string& frontend_type);
 
   bool m_enable_hist, m_enable_mean_rms, m_enable_fourier, m_enable_fourier_sum;
   int m_clock_frequency;

--- a/src/DFModule.hpp
+++ b/src/DFModule.hpp
@@ -72,14 +72,14 @@ DFModule::DFModule(bool enable_hist, bool enable_mean_rms, bool enable_fourier, 
     m_fourier = std::make_shared<FourierContainer>("fft_display",
                                                     CHANNELS_PER_LINK * m_ids.size(),
                                                     m_ids,
-                                                   1. / m_clock_frequency * (strcmp(frontend_type, "wib") ? 32 : 25),
+                                                   1. / m_clock_frequency * (strcmp(frontend_type.c_str(), "wib") ? 32 : 25),
                                                     m_num_frames);
   }
   if (m_enable_fourier_sum) {
     m_fourier_sum = std::make_shared<FourierContainer>("fft_sums_display",
                                                        4,
                                                        m_ids,
-                                                       1. / m_clock_frequency * (strcmp(frontend_type, "wib") ? 32 : 25),
+                                                       1. / m_clock_frequency * (strcmp(frontend_type.c_str(), "wib") ? 32 : 25),
                                                        m_num_frames,
                                                        true);
   }

--- a/src/DFModule.hpp
+++ b/src/DFModule.hpp
@@ -50,7 +50,7 @@ private:
 };
 
 DFModule::DFModule(bool enable_hist, bool enable_mean_rms, bool enable_fourier, bool enable_fourier_sum,
-                   int clock_frequency, std::vector<int>& ids, int num_frames) :
+                   int clock_frequency, std::vector<int>& ids, int num_frames, std::string& frontend_type) :
     m_enable_hist(enable_hist),
     m_enable_mean_rms(enable_mean_rms),
     m_enable_fourier(enable_fourier),
@@ -62,24 +62,24 @@ DFModule::DFModule(bool enable_hist, bool enable_mean_rms, bool enable_fourier, 
 {
   if (m_enable_hist) {
     m_hist = std::make_shared<HistContainer>(
-                                                 "raw_display", CHANNELS_PER_LINK * m_ids.size(), m_ids, 100, 0, 5000, false);
+                                                 "raw_display", CHANNELS_PER_LINK * m_ids.size(), m_ids, 100, 0, 17000, false);
   }
   if (m_enable_mean_rms) {
     m_mean_rms = std::make_shared<HistContainer>(
-                                                     "rmsm_display", CHANNELS_PER_LINK * m_ids.size(), m_ids, 100, 0, 5000, true);
+                                                     "rmsm_display", CHANNELS_PER_LINK * m_ids.size(), m_ids, 100, 0, 17000, true);
   }
   if (m_enable_fourier) {
     m_fourier = std::make_shared<FourierContainer>("fft_display",
                                                     CHANNELS_PER_LINK * m_ids.size(),
                                                     m_ids,
-                                                    1. / m_clock_frequency * TICKS_BETWEEN_TIMESTAMP,
+                                                   1. / m_clock_frequency * (strcmp(frontend_type, "wib") ? 32 : 25),
                                                     m_num_frames);
   }
   if (m_enable_fourier_sum) {
     m_fourier_sum = std::make_shared<FourierContainer>("fft_sums_display",
                                                        4,
                                                        m_ids,
-                                                       1. / m_clock_frequency * TICKS_BETWEEN_TIMESTAMP,
+                                                       1. / m_clock_frequency * (strcmp(frontend_type, "wib") ? 32 : 25),
                                                        m_num_frames,
                                                        true);
   }

--- a/src/FourierContainer.hpp
+++ b/src/FourierContainer.hpp
@@ -207,7 +207,7 @@ FourierContainer::run_wib2frame(std::unique_ptr<daqdataformats::TriggerRecord> r
   auto size = wibframes.begin()->second.size();
   for (auto& vec : wibframes) {
     if (vec.second.size() != size) {
-      TLOG() << "Size for each fragment is different, the first fragment has size " << second.size() << " but got size " << vec.second.size();
+      TLOG() << "Size for each fragment is different, the first fragment has size " << size << " but got size " << vec.second.size();
   //     ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
   //     return std::move(record);
     }

--- a/src/FourierContainer.hpp
+++ b/src/FourierContainer.hpp
@@ -205,12 +205,13 @@ FourierContainer::run_wib2frame(std::unique_ptr<daqdataformats::TriggerRecord> r
   // Check that all the wibframes vectors have the same size, if not, something
   // bad has happened, for now don't do anything
   auto size = wibframes.begin()->second.size();
-  // for (auto& vec : wibframes) {
-  //   if (vec.second.size() != size) {
+  for (auto& vec : wibframes) {
+    if (vec.second.size() != size) {
+      TLOG() << "Size for each fragment is different, the first fragment has size " << second.size() << " but got size " << vec.second.size();
   //     ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
   //     return std::move(record);
-  //   }
-  // }
+    }
+  }
 
   // Normal mode, fourier transform for every channel
   if (!m_global_mode) {

--- a/src/HistContainer.hpp
+++ b/src/HistContainer.hpp
@@ -225,26 +225,26 @@ HistContainer::run_wib2frame(std::unique_ptr<daqdataformats::TriggerRecord> reco
     keys.push_back(key);
   }
 
-  uint64_t min_timestamp = 0; // NOLINT(build/unsigned)
+  uint64_t min_timestamp = -1; // NOLINT(build/unsigned)
   // We run over all links until we find one that has a non-empty vector of frames
   for (auto& key : keys) {
     if (!wibframes[key].empty()) {
-      min_timestamp = wibframes[key].front()->get_timestamp();
-      break;
+      min_timestamp = std::min(wibframes[key].front()->get_timestamp(), min_timestamp);
     }
   }
   uint64_t timestamp = 0; // NOLINT(build/unsigned)
 
   // Check that all the wibframes vectors have the same size, if not, something
   // bad has happened, for now don't do anything
-  // auto size = wibframes.begin()->second.size();
-  // for (auto& vec : wibframes) {
-  //   if (vec.second.size() != size) {
-  //     ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
-  //     set_is_running(false);
-  //     return std::move(record);
-  //   }
-  // }
+  auto size = wibframes.begin()->second.size();
+  for (auto& vec : wibframes) {
+    if (vec.second.size() != size) {
+      // ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
+      TLOG() << "Size for each fragment is different, the first fragment has size " << second.size() << " but got size " << vec.second.size();
+      // set_is_running(false);
+      // return std::move(record);
+    }
+  }
 
 
   // Main loop

--- a/src/HistContainer.hpp
+++ b/src/HistContainer.hpp
@@ -240,7 +240,7 @@ HistContainer::run_wib2frame(std::unique_ptr<daqdataformats::TriggerRecord> reco
   for (auto& vec : wibframes) {
     if (vec.second.size() != size) {
       // ers::error(InvalidData(ERS_HERE, "the size of the vector of frames is different for each link"));
-      TLOG() << "Size for each fragment is different, the first fragment has size " << second.size() << " but got size " << vec.second.size();
+      TLOG() << "Size for each fragment is different, the first fragment has size " << size << " but got size " << vec.second.size();
       // set_is_running(false);
       // return std::move(record);
     }


### PR DESCRIPTION
This PR has changes related to:
- Better handling of timestamps in cases like the HD coldbox where they are not aligned
- Better handling of the case when fragments have different number of frames, like when the requests to readout do not correspond to an integer number of frames (when requesting a window of time that corresponds to 4.5 frames for example)