### PR TITLE
Make DQM more robust

### DIFF
--- a/include/dqm/Issues.hpp
+++ b/include/dqm/Issues.hpp
@@ -44,11 +44,13 @@ ERS_DECLARE_ISSUE(dqm, EmptyData, "Data is empty after removing empty fragments"
 
 ERS_DECLARE_ISSUE(dqm, TimestampsNotAligned, "Timestamps are not aligned, DQM will align them", ((std::string)empty))
 
-ERS_DECLARE_ISSUE(dqm, InvalidInput, "Invalid input: ", ((std::string)why))
+ERS_DECLARE_ISSUE(dqm, InvalidInput, "Invalid input: " << why, ((std::string)why))
 
 ERS_DECLARE_ISSUE(dqm, BadCrateSlotFiber,
                   "Bad crate, slot, fiber: (" << crate << ", " << slot << ", " << fiber << ")",
                   ((int)crate)((int)slot)((int)fiber))
+
+ERS_DECLARE_ISSUE(dqm, ParameterChange, "Parameters changed: " << why, ((std::string)why))
 
 
 } // namespace dunedaq

--- a/include/dqm/Pipeline.hpp
+++ b/include/dqm/Pipeline.hpp
@@ -31,7 +31,7 @@ remove_empty(std::map<int, std::vector<T*>>& map)
   TLOG(TLVL_WORK_STEPS) << "Removing empty fragments";
   bool empty_fragments = false;
   for (auto& [key, val] : map)
-    if (not val.size()) {
+    if (not val.size() || val.size() == sizeof(daqdataformats::FragmentHeader)) {
       empty_fragments = true;
       map.erase(key);
     }

--- a/include/dqm/algs/Fourier.hpp
+++ b/include/dqm/algs/Fourier.hpp
@@ -59,12 +59,15 @@ Fourier::Fourier(double inc, int npoints) // NOLINT(build/unsigned)
  */
 void
 Fourier::compute_fourier_transform() {
+
+  if (m_data.size() != (size_t)m_npoints) {
+    m_npoints = m_data.size();
+    ers::warning(ParameterChange(ERS_HERE, "input doesn't have the expected size for the Fourier transform, changing size to " + std::to_string(m_npoints)));
+  }
+
   if (m_transform.size() != (size_t)m_npoints)
     m_transform.resize(m_npoints);
-  if (m_data.size() != (size_t)m_npoints) {
-    ers::error(InvalidData(ERS_HERE, "input doesn't have the expected size for the Fourier transform"));
-    return;
-  }
+
   // A plan is created, executed and destroyed each time_t
   // Not the most efficient way but using the new-array interface
   // and creating a single plan that is passed around crashes for

--- a/src/RMSModule.hpp
+++ b/src/RMSModule.hpp
@@ -120,16 +120,14 @@ RMSModule::run_(std::unique_ptr<daqdataformats::TriggerRecord> record,
     keys.push_back(key);
   }
 
-  for (size_t ifr = 0; ifr < frames[keys[0]].size(); ++ifr) {
-    // Fill for every link
-    for (size_t ikey = 0; ikey < keys.size(); ++ikey) {
-      auto fr = frames[keys[ikey]][ifr];
-
+  for (const auto& [key, vec] : frames) {
+    for (const auto& fr : vec) {
       for (int ich = 0; ich < CHANNELS_PER_LINK; ++ich) {
-        fill(ich, keys[ikey], get_adc<T>(fr, ich));
+        fill(ich, key, get_adc<T>(fr, ich));
       }
     }
   }
+
   transmit(args.kafka_address,
            map,
            args.kafka_topic,

--- a/src/RMSModule.hpp
+++ b/src/RMSModule.hpp
@@ -108,9 +108,9 @@ RMSModule::run_(std::unique_ptr<daqdataformats::TriggerRecord> record,
   auto map = args.map;
 
   auto frames = decode<T>(*record, args.max_frames);
-  auto pipe = Pipeline<T>({"remove_empty", "check_empty", "make_same_size", "check_timestamp_aligned"});
-  pipe(frames);
-  if (frames.size() == 0) {
+  auto pipe = Pipeline<T>({"remove_empty", "check_empty", "check_timestamps_aligned"});
+  bool valid_data = pipe(frames);
+  if (!valid_data) {
     return record;
   }
 

--- a/src/STDModule.hpp
+++ b/src/STDModule.hpp
@@ -121,16 +121,14 @@ STDModule::run_(std::unique_ptr<daqdataformats::TriggerRecord> record,
     keys.push_back(key);
   }
 
-  for (size_t ifr = 0; ifr < frames[keys[0]].size(); ++ifr) {
-    // Fill for every link
-    for (size_t ikey = 0; ikey < keys.size(); ++ikey) {
-      auto fr = frames[keys[ikey]][ifr];
-
+  for (const auto& [key, vec] : frames) {
+    for (const auto& fr : vec) {
       for (int ich = 0; ich < CHANNELS_PER_LINK; ++ich) {
-        fill(ich, keys[ikey], get_adc<T>(fr, ich));
+        fill(ich, key, get_adc<T>(fr, ich));
       }
     }
   }
+
   transmit(args.kafka_address,
            map,
            args.kafka_topic,

--- a/src/STDModule.hpp
+++ b/src/STDModule.hpp
@@ -109,8 +109,11 @@ STDModule::run_(std::unique_ptr<daqdataformats::TriggerRecord> record,
   auto map = args.map;
 
   auto frames = decode<T>(*record, args.max_frames);
-  auto pipe = Pipeline<T>({"remove_empty", "check_empty", "make_same_size", "check_timestamp_aligned"});
-  pipe(frames);
+  auto pipe = Pipeline<T>({"remove_empty", "check_empty", "check_timestamps_aligned"});
+  bool valid_data = pipe(frames);
+  if (!valid_data) {
+    return record;
+  }
   if (frames.size() == 0) {
     return record;
   }

--- a/src/STDModule.hpp
+++ b/src/STDModule.hpp
@@ -114,9 +114,6 @@ STDModule::run_(std::unique_ptr<daqdataformats::TriggerRecord> record,
   if (!valid_data) {
     return record;
   }
-  if (frames.size() == 0) {
-    return record;
-  }
 
   // Get all the keys
   std::vector<int> keys;


### PR DESCRIPTION
The changes in this PR should make DQM more robust by removing some of the indexing logic and using iterators instead and adding more checks for the fourier transform. Test with and without TPG without problems