### PR TITLE
DQMProcessor connection changes as part of the Connectivity Service consolidation

### DIFF
--- a/include/dqm/ChannelStream.hpp
+++ b/include/dqm/ChannelStream.hpp
@@ -120,7 +120,7 @@ template <class T, class I>
 template <class R>
 void
 ChannelStream<T, I>::run_(std::shared_ptr<daqdataformats::TriggerRecord> record,
-                DQMArgs& args, DQMInfo& info)
+                          DQMArgs& args, DQMInfo& /*info*/)
 {
   auto map = args.map;
 

--- a/include/dqm/Issues.hpp
+++ b/include/dqm/Issues.hpp
@@ -56,6 +56,8 @@ ERS_DECLARE_ISSUE(dqm, ModuleNotImported, "Python module " << module << " couldn
 
 ERS_DECLARE_ISSUE(dqm, PythonModuleCrashed, "Python module " << module << " crashed", ((std::string)module))
 
+ERS_DECLARE_ISSUE(dqm, MissingConnection, "The " << conn_desc << " connection is not available, and this will prevent this module from working correctly. This problem is probably the result of a mistake in the connection information given to this module at INIT time, please check that information for possible problems.", ((std::string)conn_desc))
+
 } // namespace dunedaq
 
 #endif // DQM_INCLUDE_DQM_ISSUES_HPP_

--- a/include/dqm/modules/FourierContainer.hpp
+++ b/include/dqm/modules/FourierContainer.hpp
@@ -108,7 +108,7 @@ FourierContainer::run_(std::shared_ptr<daqdataformats::TriggerRecord> record,
     return;
   }
 
-  auto size = frames.begin()->second.size();
+  //auto size = frames.begin()->second.size();
 
   // Normal mode, fourier transform for every channel
   if (!m_global_mode) {

--- a/plugins/DQMProcessor.hpp
+++ b/plugins/DQMProcessor.hpp
@@ -73,6 +73,7 @@ private:
   std::shared_ptr<std::atomic<bool>> m_run_marker;
   std::shared_ptr<iomanager::ReceiverConcept<std::unique_ptr<daqdataformats::TriggerRecord>>> m_receiver;
   std::shared_ptr<iomanager::SenderConcept<dfmessages::TriggerDecision>> m_sender;
+  std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_timesync_receiver;
 
   std::chrono::milliseconds m_sink_timeout{ 1000 };
   std::chrono::milliseconds m_source_timeout{ 1000 };

--- a/plugins/DQMProcessor.hpp
+++ b/plugins/DQMProcessor.hpp
@@ -71,8 +71,8 @@ public:
 
 private:
   std::shared_ptr<std::atomic<bool>> m_run_marker;
-  std::shared_ptr<iomanager::ReceiverConcept<std::unique_ptr<daqdataformats::TriggerRecord>>> m_receiver;
-  std::shared_ptr<iomanager::SenderConcept<dfmessages::TriggerDecision>> m_sender;
+  std::shared_ptr<iomanager::ReceiverConcept<std::unique_ptr<daqdataformats::TriggerRecord>>> m_tr_receiver;
+  std::shared_ptr<iomanager::SenderConcept<dfmessages::TriggerDecision>> m_td_sender;
   std::shared_ptr<iomanager::ReceiverConcept<dfmessages::TimeSync>> m_timesync_receiver;
 
   std::chrono::milliseconds m_sink_timeout{ 1000 };


### PR DESCRIPTION
Most of the changes on this branch are part of our ConnectivityService consolidation work, in which we are trying to improve our handling of connections and make their use more consistent among all DAQ modules.  There were also a couple of minor changes to eliminate compiler warnings.

For the ConnSvc-related changes, I moved the creation of the timesync_receiver, td_sender, and tr_receiver to the init() method, following our recommendation to create Senders and Receivers there.  In addition, I switched to using "local connection names" to reference connections in the code, and to fetch the "global" connection names from the init-time configuration.

Because the DQMProcessor code is used for both Readout DQM and Dataflow DQM, I couldn't strictly require the presence of Readout of Dataflow connection info in the init method.  So, I based the creation of the readout-mode Sender and Receivers on the presence of the associated connection info, and added protection later in the code in case a needed Sender or Receiver is not available.

These changes should be tested in conjunction with related ones in the `daqconf` package. 

A noteworthy change to the handling of TimeSync messages is the fact that DQMProcessor now only subscribes to the TimeSyncs that are sent from the companion Readout App, instead of subscribing to all TimeSync messages from all Readout Apps.  This is accomplished by having the "global" connection name for the TimeSync messages be a regular expression that includes the name of the associated Readout App.